### PR TITLE
Using inheritance rather then a flag for regional vs global resources

### DIFF
--- a/riffdog_aws/aws_resource.py
+++ b/riffdog_aws/aws_resource.py
@@ -9,12 +9,8 @@ class AWSResource(Resource):
     Middle Inheritance to handle getting the correct client & resource objects
     """
 
-    # set this to False if this class is a Global resource (e.g. s3)
-    regional_resource = True
-
     def fetch_real_resources(self):
-        
-        if self.regional_resource:
+        if isinstance(self, AWSRegionalResource):
             for region in RDConfig().aws_regions:
                 self.fetch_real_regional_resources(region)
         else:
@@ -70,3 +66,15 @@ class AWSResource(Resource):
 
         resource = boto3.resource(aws_resource_type, region_name=region)
         return resource
+
+
+class AWSRegionalResource(AWSResource):
+
+    def fetch_real_regional_resources(self, region):
+        raise NotImplemented()
+
+
+class AWSGlobalResource(AWSResource):
+
+    def fetch_real_global_resources(self):
+        raise NotImplemented()

--- a/riffdog_aws/resources/ec2/ec2_instances.py
+++ b/riffdog_aws/resources/ec2/ec2_instances.py
@@ -7,13 +7,13 @@ import logging
 from riffdog.data_structures import FoundItem
 from riffdog.resource import register, ResourceDirectory
 
-from ...aws_resource import AWSResource
+from ...aws_resource import AWSRegionalResource
 
 logger = logging.getLogger(__name__)
 
 
 @register("aws_instance")
-class AWSInstance(AWSResource):
+class AWSInstance(AWSRegionalResource):
     resource_type = "aws_instance"
 
     def fetch_real_regional_resources(self, region):

--- a/riffdog_aws/resources/elbv2/lb.py
+++ b/riffdog_aws/resources/elbv2/lb.py
@@ -7,14 +7,14 @@ import logging
 from riffdog.data_structures import FoundItem
 from riffdog.resource import register, ResourceDirectory
 
-from ...aws_resource import AWSResource
+from ...aws_resource import AWSRegionalResource
 
 
 logger = logging.getLogger(__name__)
 
 
 @register("aws_lb", "aws_alb")
-class AWSLB(AWSResource):
+class AWSLB(AWSRegionalResource):
     _lbs_in_aws = None
 
     def __init__(self, *args, **kwargs):

--- a/riffdog_aws/resources/elbv2/lb_listener.py
+++ b/riffdog_aws/resources/elbv2/lb_listener.py
@@ -7,13 +7,13 @@ import logging
 from riffdog.data_structures import FoundItem
 from riffdog.resource import register, ResourceDirectory
 
-from ...aws_resource import AWSResource
+from ...aws_resource import AWSRegionalResource
 
 logger = logging.getLogger(__name__)
 
 
 @register("aws_lb_listener", "aws_alb_listener")
-class AWSLBListener(AWSResource):
+class AWSLBListener(AWSRegionalResource):
 
     _listeners_in_aws = None
     depends_on = ["aws_lb"]
@@ -55,7 +55,7 @@ class AWSLBListener(AWSResource):
 
 
 @register("aws_lb_listener_rule", "aws_alb_listener_rule")
-class AWSLBListenerRule(AWSResource):
+class AWSLBListenerRule(AWSRegionalResource):
     # All aws_alb_* will be stored as aws_lb_*
     _rules_in_aws = None
     depends_on = ["aws_lb_listener"]
@@ -93,7 +93,7 @@ class AWSLBListenerRule(AWSResource):
 
 
 @register("aws_lb_listener_certificate", "aws_alb_listener_certificate")
-class AWSLBListenerCertificate(AWSResource):
+class AWSLBListenerCertificate(AWSRegionalResource):
     # All aws_alb_* will be stored as aws_lb_*
     resource_type = "aws_lb_listener_certificate"
     depends_on = ["aws_lb_listener"]

--- a/riffdog_aws/resources/elbv2/lb_target_group.py
+++ b/riffdog_aws/resources/elbv2/lb_target_group.py
@@ -7,13 +7,13 @@ import logging
 from riffdog.data_structures import FoundItem
 from riffdog.resource import register, ResourceDirectory
 
-from ...aws_resource import AWSResource
+from ...aws_resource import AWSRegionalResource
 
 logger = logging.getLogger(__name__)
 
 
 @register("aws_lb_target_group", "aws_alb_target_group")
-class AWSLBTargetGroup(AWSResource):
+class AWSLBTargetGroup(AWSRegionalResource):
     # All aws_alb_* will be stored as aws_lb_*
     _tgs_in_aws = None
 
@@ -53,7 +53,7 @@ class AWSLBTargetGroup(AWSResource):
 
 
 @register("aws_lb_target_group_attachment", "aws_alb_target_group_attachment")
-class AWSLBTargetGroupAttachment(AWSResource):
+class AWSLBTargetGroupAttachment(AWSRegionalResource):
     # All aws_alb_* will be stored as aws_lb_*
     depends_on = ["aws_lb_target_group"]
 

--- a/riffdog_aws/resources/lambda/lambda_function.py
+++ b/riffdog_aws/resources/lambda/lambda_function.py
@@ -3,17 +3,16 @@ import logging
 from riffdog.data_structures import FoundItem
 from riffdog.resource import register, ResourceDirectory
 
-from ...aws_resource import AWSResource
+from ...aws_resource import AWSRegionalResource
 
 logger = logging.getLogger(__name__)
 
 
 @register("aws_lambda_function")
-class AWSLambdaFunction(AWSResource):
+class AWSLambdaFunction(AWSRegionalResource):
     """
     This is aws Lambda functions
     """
-    resource_type = "aws_lambda_function"
 
     def fetch_real_regional_resources(self, region):
         logging.info("Looking for %s resources..." % self.resource_type)

--- a/riffdog_aws/resources/rds/cluster_parameter_group.py
+++ b/riffdog_aws/resources/rds/cluster_parameter_group.py
@@ -7,13 +7,13 @@ import logging
 from riffdog.data_structures import FoundItem
 from riffdog.resource import register, ResourceDirectory
 
-from ...aws_resource import AWSResource
+from ...aws_resource import AWSRegionalResource
 
 logger = logging.getLogger(__name__)
 
 
 @register("aws_rds_cluster_parameter_group")
-class AWSRDSClusterParameterGroup(AWSResource):
+class AWSRDSClusterParameterGroup(AWSRegionalResource):
     resource_type = "aws_rds_cluster_parameter_group"
 
     def fetch_real_regional_resources(self, region):

--- a/riffdog_aws/resources/rds/db_cluster.py
+++ b/riffdog_aws/resources/rds/db_cluster.py
@@ -7,14 +7,13 @@ import logging
 from riffdog.data_structures import FoundItem
 from riffdog.resource import register, ResourceDirectory
 
-from ...aws_resource import AWSResource
+from ...aws_resource import AWSRegionalResource
 
 logger = logging.getLogger(__name__)
 
 
 @register("aws_rds_cluster")
-class AWSRDSCluster(AWSResource):
-    resource_type = "aws_rds_cluster"
+class AWSRDSCluster(AWSRegionalResource):
 
     def fetch_real_regional_resources(self, region):
         logging.info("Looking for %s resources..." % self.resource_type)
@@ -41,7 +40,7 @@ class AWSRDSCluster(AWSResource):
 
 
 @register("aws_rds_cluster_instance")
-class AWSRDSClusterInstance(AWSResource):
+class AWSRDSClusterInstance(AWSRegionalResource):
     """
     These are a faux thing to Terraform. An aws_rds_cluster_instance is
     just an aws_db_instance that belongs to a Cluster.

--- a/riffdog_aws/resources/rds/db_instance.py
+++ b/riffdog_aws/resources/rds/db_instance.py
@@ -3,14 +3,13 @@ import logging
 from riffdog.data_structures import FoundItem
 from riffdog.resource import register, ResourceDirectory
 
-from ...aws_resource import AWSResource
+from ...aws_resource import AWSRegionalResource
 
 logger = logging.getLogger(__name__)
 
 
 @register("aws_db_instance")
-class AWSDBInstance(AWSResource):
-    resource_type = "aws_db_instance"
+class AWSDBInstance(AWSRegionalResource):
 
     def fetch_real_regional_resources(self, region):
         logging.info("Looking for %s resources..." % self.resource_type)

--- a/riffdog_aws/resources/s3.py
+++ b/riffdog_aws/resources/s3.py
@@ -6,15 +6,13 @@ import logging
 from riffdog.data_structures import FoundItem
 from riffdog.resource import register, ResourceDirectory
 
-from ..aws_resource import AWSResource
+from ..aws_resource import AWSGlobalResource
 
 logger = logging.getLogger(__name__)
 
 
 @register("aws_s3_bucket")
-class AWSS3Bucket(AWSResource):
-    resource_type = "aws_s3_bucket"
-    regional_resource = False
+class AWSS3Bucket(AWSGlobalResource):
 
     def fetch_real_global_resources(self):
         logging.info("Looking for %s resources..." % self.resource_type)

--- a/riffdog_aws/resources/vpc/subnet.py
+++ b/riffdog_aws/resources/vpc/subnet.py
@@ -6,14 +6,13 @@ import logging
 from riffdog.data_structures import FoundItem
 from riffdog.resource import register, ResourceDirectory
 
-from ...aws_resource import AWSResource
+from ...aws_resource import AWSRegionalResource
 
 logger = logging.getLogger(__name__)
 
 
 @register("aws_subnet")
-class AWSSubnet(AWSResource):
-    resource_type = "aws_subnet"
+class AWSSubnet(AWSRegionalResource):
 
     def fetch_real_regional_resources(self, region):
         logging.info("Looking for %s resources..." % self.resource_type)

--- a/riffdog_aws/resources/vpc/vpc.py
+++ b/riffdog_aws/resources/vpc/vpc.py
@@ -6,14 +6,13 @@ import logging
 from riffdog.data_structures import FoundItem
 from riffdog.resource import register, ResourceDirectory
 
-from ...aws_resource import AWSResource
+from ...aws_resource import AWSRegionalResource
 
 logger = logging.getLogger(__name__)
 
 
 @register("aws_vpc")
-class AWSVPC(AWSResource):
-    resource_type = "aws_vpc"
+class AWSVPC(AWSRegionalResource):
 
     def fetch_real_regional_resources(self, region):
         logging.info("Looking for %s resources..." % self.resource_type)


### PR DESCRIPTION
So in this design, instead of doing:

```
class SomeResource(AWSResource):
     regional_resource = False # is this supposed to be True? or False? Hrmm
   
     def fetch_real_regional_resources(self, region):
         do_stuff()
```

you now get the slightly (in my opinion) easier:

```
class SomeResource(AWSRegionalResource):
      def fetch_real_regional_resources(self, region):
```

or

```
class SomeResource(AWSGlobalResource):
    def fetch_real_global_resources(self):
```

And you get the same crashing-exception if you don't implement that.